### PR TITLE
fix: navbar links improperly highlighted

### DIFF
--- a/src/components/navbar-link.astro
+++ b/src/components/navbar-link.astro
@@ -5,8 +5,12 @@ export interface Props {
 
 const { href } = Astro.props;
 
-let active = Astro.url.pathname === href;
-if (Astro.url.pathname.startsWith("/blog") && href === "/blog") active = true;
+let active = false;
+if (href === "/" && Astro.url.pathname === "/") {
+  active = true;
+} else if (Astro.url.pathname.startsWith(href)) {
+  active = true;
+}
 ---
 
 <a

--- a/src/components/navbar-link.astro
+++ b/src/components/navbar-link.astro
@@ -6,8 +6,8 @@ export interface Props {
 const { href } = Astro.props;
 
 let active = false;
-if (href === "/" && Astro.url.pathname === "/") {
-  active = true;
+if (href === "/") {
+  if (Astro.url.pathname === "/") active = true;
 } else if (Astro.url.pathname.startsWith(href)) {
   active = true;
 }

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -13,6 +13,7 @@ import ThemeIcon from "./theme-icon.astro";
       <NavbarLink href="/blog">Blog</NavbarLink>
       <NavbarLink href="/gallery">Gallery</NavbarLink>
     </nav>
+    <p>{Astro.url.pathname}</p>
     <div class="flex gap-2">
       <SearchIcon />
       <ThemeIcon />

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -13,7 +13,6 @@ import ThemeIcon from "./theme-icon.astro";
       <NavbarLink href="/blog">Blog</NavbarLink>
       <NavbarLink href="/gallery">Gallery</NavbarLink>
     </nav>
-    <p>{Astro.url.pathname}</p>
     <div class="flex gap-2">
       <SearchIcon />
       <ThemeIcon />


### PR DESCRIPTION
- Resolves #1

`Astro.url.pathname` returns the pathname without a trailing `/` in development, but with a trailing `/` when deployed (this is sort of documented [here](https://docs.astro.build/en/reference/configuration-reference/#effect-on-astrourl)). Because of this, my check to see which navlink should be highlighted did not work properly. I changed up the logic a bit and it should be all good now.