### PR TITLE
dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Astro Blog
 
-| Command                | Action                                           |
-| :--------------------- | :----------------------------------------------- |
-| `npm install`          | Installs dependencies                            |
-| `npm run dev`          | Starts local dev server at `localhost:3000`      |
-| `npm run build`        | Build your production site to `./dist/`          |
-| `npm run preview`      | Preview your build locally, before deploying     |
-| `npm run astro ...`    | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro --help` | Get help using the Astro CLI                     |
+| Command                 | Action                                           |
+| :---------------------- | :----------------------------------------------- |
+| `npm install`           | Installs dependencies                            |
+| `npm run dev`           | Starts local dev server at `localhost:3000`      |
+| `npm run dev -- --host` | Starts local dev server on all interfaces        |
+| `npm run build`         | Build your production site to `./dist/`          |
+| `npm run preview`       | Preview your build locally, before deploying     |
+| `npm run astro ...`     | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro --help`  | Get help using the Astro CLI                     |

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,9 @@ import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 
 // https://astro.build/config
+import react from "@astrojs/react";
+
+// https://astro.build/config
 export default defineConfig({
-  integrations: [tailwind()],
+  integrations: [tailwind(), react()]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,14 @@
 			"name": "astro-blog",
 			"version": "0.0.1",
 			"dependencies": {
+				"@astrojs/react": "^2.0.2",
 				"@astrojs/tailwind": "^3.0.1",
+				"@types/react": "^18.0.28",
+				"@types/react-dom": "^18.0.11",
 				"astro": "^2.0.14",
 				"pocketbase": "^0.10.2",
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0",
 				"tailwindcss": "^3.2.7"
 			},
 			"devDependencies": {
@@ -93,6 +98,24 @@
 			},
 			"engines": {
 				"node": ">=16.12.0"
+			}
+		},
+		"node_modules/@astrojs/react": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-2.0.2.tgz",
+			"integrity": "sha512-UmQNvzJul5M/Q9aZJXnqz4z0ODZXkLuaNvgsYoKB7OdM8c2v85FsTjMZZJ7BvFo4On31jJ0rL/gwTaCeuYqmpw==",
+			"dependencies": {
+				"@babel/core": ">=7.0.0-0 <8.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.17.12"
+			},
+			"engines": {
+				"node": ">=16.12.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17.0.50 || ^18.0.21",
+				"@types/react-dom": "^17.0.17 || ^18.0.6",
+				"react": "^17.0.2 || ^18.0.0",
+				"react-dom": "^17.0.2 || ^18.0.0"
 			}
 		},
 		"node_modules/@astrojs/tailwind": {
@@ -1070,10 +1093,38 @@
 			"resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
 			"integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.5",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+		},
+		"node_modules/@types/react": {
+			"version": "18.0.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+			"integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.0.11",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+			"integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+			"dependencies": {
+				"@types/react": "*"
+			}
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
+		},
+		"node_modules/@types/scheduler": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.6",
@@ -1779,6 +1830,11 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/csstype": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+			"integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -2744,6 +2800,17 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -4151,6 +4218,29 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/react": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.0"
+			},
+			"peerDependencies": {
+				"react": "^18.2.0"
+			}
+		},
 		"node_modules/read-cache": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4505,6 +4595,14 @@
 			"integrity": "sha512-hXdxU6PCkiV3XAiSnX+XLqz2ohHoEnVUlrd8LEVMAI80uB1+OTScIkH9n6qQwImZpTye1r1WG1rbGUteHNhoHg==",
 			"dependencies": {
 				"suf-log": "^2.5.3"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+			"integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
 			}
 		},
 		"node_modules/section-matter": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,14 @@
 		"astro": "astro"
 	},
 	"dependencies": {
+		"@astrojs/react": "^2.0.2",
 		"@astrojs/tailwind": "^3.0.1",
+		"@types/react": "^18.0.28",
+		"@types/react-dom": "^18.0.11",
 		"astro": "^2.0.14",
 		"pocketbase": "^0.10.2",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
 		"tailwindcss": "^3.2.7"
 	},
 	"devDependencies": {

--- a/src/components/navbar-link.astro
+++ b/src/components/navbar-link.astro
@@ -15,10 +15,10 @@ if (href === "/") {
 
 <a
   href={href}
-  class={`px-3 py-1 rounded-md ${
+  class={`px-3 py-1 rounded-md transition-colors ${
     active
-      ? "bg-zinc-400 dark:bg-zinc-700 bg-opacity-50"
-      : "dark:text-zinc-400 dark:hover:text-zinc-200"
+      ? "bg-zinc-400 bg-opacity-30 dark:bg-zinc-700 dark:bg-opacity-50"
+      : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
   }`}
 >
   <slot />

--- a/src/components/navbar-link.astro
+++ b/src/components/navbar-link.astro
@@ -15,8 +15,10 @@ if (href === "/") {
 
 <a
   href={href}
-  class={`px-3 py-1 rounded-md transition-colors ${
-    active ? "bg-zinc-700 bg-opacity-50" : "text-zinc-400 hover:text-zinc-200"
+  class={`px-3 py-1 rounded-md ${
+    active
+      ? "bg-zinc-400 dark:bg-zinc-700 bg-opacity-50"
+      : "dark:text-zinc-400 dark:hover:text-zinc-200"
   }`}
 >
   <slot />

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -4,7 +4,9 @@ import SearchIcon from "./search-icon.astro";
 import ThemeIcon from "./theme-icon";
 ---
 
-<div class="bg-zinc-300 dark:bg-zinc-800 dark:bg-opacity-50">
+<div
+  class="bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-50 border-b border-zinc-300 dark:border-zinc-700"
+>
   <div class="container mx-auto flex justify-between p-4 items-center">
     <h1 class="font-handwriting text-2xl leading-none">Zachary Robinson</h1>
     <nav class="flex gap-2">

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -9,7 +9,7 @@ import ThemeIcon from "./theme-icon";
 >
   <div class="container mx-auto flex justify-between p-4 items-center">
     <h1 class="font-handwriting text-2xl leading-none">Zachary Robinson</h1>
-    <nav class="flex gap-2">
+    <nav class="flex gap-2 absolute left-1/2 -translate-x-1/2">
       <NavbarLink href="/">Home</NavbarLink>
       <NavbarLink href="/about">About</NavbarLink>
       <NavbarLink href="/blog">Blog</NavbarLink>

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -1,7 +1,7 @@
 ---
 import NavbarLink from "./navbar-link.astro";
 import SearchIcon from "./search-icon.astro";
-import ThemeIcon from "./theme-icon.astro";
+import ThemeIcon from "./theme-icon";
 ---
 
 <div class="bg-zinc-800 bg-opacity-50">
@@ -14,8 +14,21 @@ import ThemeIcon from "./theme-icon.astro";
       <NavbarLink href="/gallery">Gallery</NavbarLink>
     </nav>
     <div class="flex gap-2">
-      <SearchIcon />
-      <ThemeIcon />
+      <div class="w-6 h-6">
+        <SearchIcon />
+      </div>
+      <div class="w-6 h-6">
+        <ThemeIcon client:only="react" />
+
+        <noscript title="Please Enable Javascript to Switch Themes">
+          <!-- prettier-ignore -->
+          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-sun" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+            <path d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"></path>
+            <path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
+          </svg>
+        </noscript>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -8,7 +8,9 @@ import ThemeIcon from "./theme-icon";
   class="bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-50 border-b border-zinc-300 dark:border-zinc-700"
 >
   <div class="container mx-auto flex justify-between p-4 items-center">
-    <h1 class="font-handwriting text-2xl leading-none">Zachary Robinson</h1>
+    <a href="/">
+      <h1 class="font-handwriting text-2xl leading-none">Zachary Robinson</h1>
+    </a>
     <nav class="flex gap-2 absolute left-1/2 -translate-x-1/2">
       <NavbarLink href="/">Home</NavbarLink>
       <NavbarLink href="/about">About</NavbarLink>

--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -4,7 +4,7 @@ import SearchIcon from "./search-icon.astro";
 import ThemeIcon from "./theme-icon";
 ---
 
-<div class="bg-zinc-800 bg-opacity-50">
+<div class="bg-zinc-300 dark:bg-zinc-800 dark:bg-opacity-50">
   <div class="container mx-auto flex justify-between p-4 items-center">
     <h1 class="font-handwriting text-2xl leading-none">Zachary Robinson</h1>
     <nav class="flex gap-2">

--- a/src/components/theme-icon.astro
+++ b/src/components/theme-icon.astro
@@ -1,6 +1,0 @@
-<!-- prettier-ignore -->
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-sun" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-  <path d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"></path>
-  <path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
-</svg>

--- a/src/components/theme-icon.tsx
+++ b/src/components/theme-icon.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+export default function ThemeIcon() {
+  const [darkMode, setDarkMode] = useState(
+    document.documentElement.classList.contains("dark")
+  );
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }, [darkMode]);
+
+  return (
+    <button onClick={() => setDarkMode((x) => !x)}>
+      {darkMode ? (
+        /* prettier-ignore */
+        <svg xmlns="http://www.w3.org/2000/svg" className="icon icon-tabler icon-tabler-sun" width="24" height="24" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+          <path d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"></path>
+          <path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
+        </svg>
+      ) : (
+        /* prettier-ignore */
+        <svg xmlns="http://www.w3.org/2000/svg" className="icon icon-tabler icon-tabler-moon" width="24" height="24" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+          <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z"></path>
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/theme-icon.tsx
+++ b/src/components/theme-icon.tsx
@@ -16,7 +16,10 @@ export default function ThemeIcon() {
   }, [darkMode]);
 
   return (
-    <button onClick={() => setDarkMode((x) => !x)}>
+    <button
+      onClick={() => setDarkMode((x) => !x)}
+      aria-label="Toggle Between Light and Dark Theme"
+    >
       {darkMode ? (
         /* prettier-ignore */
         <svg xmlns="http://www.w3.org/2000/svg" className="icon icon-tabler icon-tabler-sun" width="24" height="24" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/theme-icon.tsx
+++ b/src/components/theme-icon.tsx
@@ -8,9 +8,11 @@ export default function ThemeIcon() {
   useEffect(() => {
     if (darkMode) {
       document.documentElement.classList.add("dark");
+      document.documentElement.style.setProperty("color-scheme", "dark");
       localStorage.setItem("theme", "dark");
     } else {
       document.documentElement.classList.remove("dark");
+      document.documentElement.style.setProperty("color-scheme", "light");
       localStorage.setItem("theme", "light");
     }
   }, [darkMode]);

--- a/src/layouts/root.astro
+++ b/src/layouts/root.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -26,6 +26,12 @@ const { title } = Astro.props;
         font-display: block;
       }
     </style>
+
+    <script>
+      if (localStorage.getItem("theme") === "light") {
+        document.documentElement.classList.remove("dark");
+      }
+    </script>
   </head>
   <body class="bg-zinc-900 text-zinc-50">
     <Navbar />

--- a/src/layouts/root.astro
+++ b/src/layouts/root.astro
@@ -9,7 +9,7 @@ const { title } = Astro.props;
 ---
 
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" class="dark" style={{ colorScheme: "dark" }}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -30,6 +30,7 @@ const { title } = Astro.props;
     <script>
       if (localStorage.getItem("theme") === "light") {
         document.documentElement.classList.remove("dark");
+        document.documentElement.style.setProperty("color-scheme", "light");
       }
     </script>
   </head>

--- a/src/layouts/root.astro
+++ b/src/layouts/root.astro
@@ -33,7 +33,7 @@ const { title } = Astro.props;
       }
     </script>
   </head>
-  <body class="bg-zinc-900 text-zinc-50">
+  <body class="bg-zinc-50 text-zinc-900 dark:bg-zinc-900 dark:text-zinc-50">
     <Navbar />
     <main class="container mx-auto p-4">
       <slot />

--- a/src/layouts/root.astro
+++ b/src/layouts/root.astro
@@ -23,7 +23,7 @@ const { title } = Astro.props;
         src: url("/fonts/WalterTurncoat-Regular.woff2") format("woff2");
         font-weight: normal;
         font-style: normal;
-        font-display: swap;
+        font-display: block;
       }
     </style>
   </head>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,10 +5,4 @@ import Root from "../layouts/root.astro";
 <Root title="Astro Blog">
   <h2 class="text-2xl font-bold">About Route</h2>
   <p>Hello World!</p>
-
-  <div class="bg-zinc-300 dark:bg-zinc-800 mt-4 p-4 rounded-md">
-    <p class="text-zinc-800 dark:text-zinc-300">
-      This is some text that's responsive to the theme!
-    </p>
-  </div>
 </Root>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,7 +2,7 @@
 import Root from "../layouts/root.astro";
 ---
 
-<Root title="Astro Blog">
+<Root title="About · Zachary Robinson">
   <h2 class="text-2xl font-bold">About Route</h2>
   <p>Hello World!</p>
 </Root>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,4 +5,10 @@ import Root from "../layouts/root.astro";
 <Root title="Astro Blog">
   <h2 class="text-2xl font-bold">About Route</h2>
   <p>Hello World!</p>
+
+  <div class="bg-zinc-300 dark:bg-zinc-800 mt-4 p-4 rounded-md">
+    <p class="text-zinc-800 dark:text-zinc-300">
+      This is some text that's responsive to the theme!
+    </p>
+  </div>
 </Root>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -5,7 +5,7 @@ import Root from "../layouts/root.astro";
 const posts = await getBlogPosts();
 ---
 
-<Root title="Astro Blog">
+<Root title="Blog · Zachary Robinson">
   <h2 class="text-2xl font-bold pb-2">Blog Posts</h2>
   <ul class="list-disc list-inside ml-4">
     {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -27,6 +27,6 @@ const { post } = Astro.props as { post: BlogPost };
   </p>
   <div
     set:html={post.content}
-    class="prose prose-invert prose-img:rounded-md"
+    class="prose prose-zinc dark:prose-invert prose-img:rounded-md"
   />
 </Root>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -14,7 +14,7 @@ export async function getStaticPaths() {
 const { post } = Astro.props as { post: BlogPost };
 ---
 
-<Root title={post.title}>
+<Root title={post.title + " · Zachary Robinson"}>
   <h1 class="font-handwriting text-4xl">{post.title}</h1>
   <p class="text-zinc-400">
     {

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -2,7 +2,7 @@
 import Root from "../layouts/root.astro";
 ---
 
-<Root title="Astro Blog">
+<Root title="Gallery · Zachary Robinson">
   <h2 class="text-2xl font-bold">Gallery Route</h2>
   <p>Hello World!</p>
 </Root>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Root from "../layouts/root.astro";
 ---
 
-<Root title="Astro Blog">
+<Root title="Zachary Robinson">
   <h2 class="text-2xl font-bold">Home Route</h2>
   <p>Hello World!</p>
 </Root>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -11,4 +11,5 @@ module.exports = {
     },
   },
   plugins: [require("@tailwindcss/typography")],
+  darkMode: "class",
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
 }


### PR DESCRIPTION
- add a toggle between light and dark mode
- more styling tweaks, such as a slight border under the navbar
- changed the [color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) of the website so that scroll bars on windows follow with the selected theme
- added sensible titles to pages (the thing up in the tabs) and made the title of the website (the thing that says my name in the navbar) a link to the home page

I'm a little disappointed that I have to ship a react runtime with the website for the toggle button. Though, javascript isn't required for the site to work, it will just default to dark mode. Even with javascript, the site will default to dark mode instead of going with the operating system's theme. I could have gone with the os theme, but after all, this is _my_ website and _I_ think dark mode is way better. But really, I do think that the site looks better in dark mode and I'd rather have users default to the version of the site that looks better.